### PR TITLE
Add debounce stamp support in Redis transport

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor
 /composer.lock
+.idea/

--- a/src/Stamp/DebounceStamp.php
+++ b/src/Stamp/DebounceStamp.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Krak\SymfonyMessengerRedis\Stamp;
+
+use Symfony\Component\Messenger\Stamp\StampInterface;
+
+/**
+ * Apply this stamp to debounce delivery of your message on a transport.
+ */
+final class DebounceStamp implements StampInterface
+{
+    private $id;
+    private $delay;
+
+    /**
+     * @param int $delay The delay in milliseconds
+     * @param string|null $id unique identifier
+     */
+    public function __construct(int $delay, ?string $id = null)
+    {
+        $this->id = $id;
+        $this->delay = $delay;
+    }
+
+    public function getId(): ?string
+    {
+        return $this->id;
+    }
+
+    public function getDelay(): int
+    {
+        return $this->delay;
+    }
+}

--- a/tests/Unit/DebounceStampTest.php
+++ b/tests/Unit/DebounceStampTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Krak\SymfonyMessengerRedis\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Krak\SymfonyMessengerRedis\Stamp\DebounceStamp;
+
+final class DebounceStampTest extends TestCase
+{
+    /** @test */
+    public function stamp_creation() {
+        $stamp = new DebounceStamp( 4000, '1234');
+        $this->assertEquals(4000, $stamp->getDelay());
+        $this->assertEquals('1234', $stamp->getId());
+    }
+
+    /**
+     * @test
+     * @dataProvider provide_stamps_for_serialization
+     */
+    public function stamp_is_serializable(DebounceStamp $stamp) {
+        $this->assertEquals($stamp, unserialize(serialize($stamp)));
+    }
+
+    public function provide_stamps_for_serialization() {
+        yield 'Stamp without id' => [new DebounceStamp(3000)];
+        yield 'Stamp with id' => [new DebounceStamp(100, '765')];
+    }
+}


### PR DESCRIPTION
- DebounceStamp that is similar to the DelayStamp, but essentially, if a debounced message is new, we enter into the queue exactly like a unique & delayed message would.
But if there is a similar message still waiting to be queued, then we would remove it, and re-add it with the new delay.