### PR TITLE
fixes "not a float" error

### DIFF
--- a/src/Transport/RedisTransport.php
+++ b/src/Transport/RedisTransport.php
@@ -81,7 +81,7 @@ final class RedisTransport implements TransportInterface, MessageCountAwareInter
             $this->getDelayedSetName(),
             $this->queue,
             $this->getProcessingQueue(),
-            microtime(true) * 1000,
+            round(microtime(true) * 1000),
         ], 4);
 
         if ($this->redis->getLastError()) {


### PR DESCRIPTION
Fixes error:
Failed to retrieve message from queue. Redis Error: ERR min or max is not a float